### PR TITLE
Fixed getMatchTimeline() and getMatch() to support MATCH-V5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
-#testing file
+#testing files
 app.js
+client.js
+index.html
+server.js
 
 
 # Logs

--- a/LeagueAPI/LeagueAPI.js
+++ b/LeagueAPI/LeagueAPI.js
@@ -38,6 +38,7 @@ const GET_MATCH_BY_MATCH_ID_AND_TOURNAMNET_CODE_URL = 'https://%region%.api.riot
 */
 
 // MATCH-V5
+const GET_MATCH_URL = 'https://%region%.api.riotgames.com/lol/match/v5/matches/%matchid%?api_key=%apikey%';
 const GET_MATCHLIST_URL = 'https://%region%.api.riotgames.com/lol/match/v5/matches/by-puuid/%puuid%/ids?api_key=%apikey%';
 
 // SPECTATOR-v4
@@ -378,13 +379,12 @@ function getRegionForMatchv5(region){
 
 function getMatchURL(matchId, apiKey, region)
 {
+  region=getRegionForMatchv5(region);
   return getURLWithRegionAndAPI(GET_MATCH_URL, apiKey, region).replace('%matchid%', matchId);
 }
 
 function getURLMatchList(puuid, apiKey, region)
 {
-  //console.log('calling getURLMatchList');
-  //console.log(puuid);
 
   region=getRegionForMatchv5(region);
 

--- a/LeagueAPI/LeagueAPI.js
+++ b/LeagueAPI/LeagueAPI.js
@@ -27,12 +27,13 @@ const GET_LEAGUE_BY_SUMMONER_URL = 'https://%region%.api.riotgames.com/lol/leagu
 // LOL-STATUS-V3
 const GET_STATUS_URL = 'https://%region%.api.riotgames.com/lol/status/v3/shard-data?api_key=%apikey%';
 
-// MATCH-V4
-//discontinued
+// MATCH-V4 is now deprecated
 /*
 const GET_MATCH_URL = 'https://%region%.api.riotgames.com/lol/match/v4/matches/%matchid%?api_key=%apikey%';
 const GET_MATCHLIST_URL = 'https://%region%.api.riotgames.com/lol/match/v4/matchlists/by-account/%accountid%?api_key=%apikey%';
 const GET_MATCH_TIMELINE_URL = 'https://%region%.api.riotgames.com/lol/match/v4/timelines/by-match/%matchid%?api_key=%apikey%';
+
+MATCH-V5 no longer contains GET urls to get matches by tournament codes. Tournament codes can now be found in getMatch responses
 const GET_MATCH_BY_TOURNAMENT_CODE_URL = 'https://%region%.api.riotgames.com/lol/match/v4/matches/by-tournament-code/%tournamentcode%/ids?api_key=%apikey%';
 const GET_MATCH_BY_MATCH_ID_AND_TOURNAMNET_CODE_URL = 'https://%region%.api.riotgames.com/lol/match/v4/matches/%matchid%/by-tournament-code/%tournamentcode%?api_key=%apikey%';
 */
@@ -40,6 +41,7 @@ const GET_MATCH_BY_MATCH_ID_AND_TOURNAMNET_CODE_URL = 'https://%region%.api.riot
 // MATCH-V5
 const GET_MATCH_URL = 'https://%region%.api.riotgames.com/lol/match/v5/matches/%matchid%?api_key=%apikey%';
 const GET_MATCHLIST_URL = 'https://%region%.api.riotgames.com/lol/match/v5/matches/by-puuid/%puuid%/ids?api_key=%apikey%';
+const GET_MATCH_TIMELINE_URL = 'https://%region%.api.riotgames.com/lol/match/v5/matches/%matchid%/timeline?api_key=%apikey%';
 
 // SPECTATOR-v4
 const GET_ACTIVE_GAME_URL = 'https://%region%.api.riotgames.com/lol/spectator/v4/active-games/by-summoner/%name%?api_key=%apikey%';
@@ -177,7 +179,11 @@ class LeagueAPI
 	
   getMatchTimeline(matchId)
   {
-    return makeAnHTTPSCall(getURLMatchTimeline(matchId, this.apiKey, this.region));
+
+    const url = getURLMatchTimeline(matchId, this.apiKey, this.region);
+
+    return createPromiseContainingLoadedData(url, this.fullyLoadClasses);
+    //return makeAnHTTPSCall(getURLMatchTimeline(matchId, this.apiKey, this.region));
   }
   
   getLeagueRanking(accountObj) 
@@ -393,6 +399,7 @@ function getURLMatchList(puuid, apiKey, region)
 
 function getURLMatchTimeline(matchId, apiKey, region)
 {
+  region=getRegionForMatchv5(region);
   return getURLWithRegionAndAPI(GET_MATCH_TIMELINE_URL, apiKey, region).replace('%matchid%', matchId);
 }
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ LeagueAPI.getFeaturedGames()
 </p>
 </details>
 
-<details><summary>getMatch(matchId)</summary>
+<details><summary>getMatch(matchId) - Match-V5</summary>
 	
 <p>
 	
@@ -156,7 +156,9 @@ LeagueAPI.getFeaturedGames()
 ```javascript
 // matchId taken from a getMatchList call
 // Gets the Match object for the ID passed
-LeagueAPI.getMatch(2970107953)
+// Now Match-V5 supported
+// matchid has a different format in Match-V5. 
+LeagueAPI.getMatch('NA1_4102250582')
 	.then(console.log)
 	.catch(console.error);
 ```

--- a/README.md
+++ b/README.md
@@ -289,14 +289,16 @@ LeagueAPI.getSummonerByName('LeagueOfDrMundo')
 </p>
 </details>
 
-<details><summary>getMatchTimeline(matchId)</summary>
+<details><summary>getMatchTimeline(matchId) - Match-V5</summary>
 	
 <p>
 	
 ####
 ```javascript
 // Returns a timeline of the match
-LeagueAPI.getMatchTimeline(3026936146)
+//Now Match-V5 supported
+// matchid has a different format in Match-V5. 
+LeagueAPI.getMatchTimeline('NA1_4102250582')
 	.then(console.log)
 	.catch(console.error);
 ```

--- a/README.md
+++ b/README.md
@@ -267,12 +267,13 @@ LeagueAPI.getSummonerByName('LeagueOfDrMundo')
 </p>
 </details>
 
-<details><summary>getMatchList(accountObject)</summary>
+<details><summary>getMatchList(accountObject) - Match-V5</summary>
 	
 <p>
 	
 ####
 ```javascript
+//Now Match-V5 supported
 LeagueAPI.getSummonerByName('LeagueOfDrMundo')
 	.then(function(accountObject) {
 		// Gets match list for the account


### PR DESCRIPTION
README.md updated to include examples for:
-  getMatch(matchId)
- getMatchList(accountObject) ( #12 ) 
- getMatchTimeline(matchId)

Highlights
- Fixed getMatchTimeline() to support MATCH-V5
- Fixed getMatch() to support MATCH-V5